### PR TITLE
Update to Julia v0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ git:
 
 ## uncomment the following lines to allow failures on nightly julia
 ## (tests will run but not make your overall status red)
-matrix:
-  allow_failures:
-  - julia: nightly
+# matrix:
+#   allow_failures:
+#   - julia: nightly
 
 ## uncomment and modify the following lines to manually install system packages
 #addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
+  - 0.7
   - nightly
 notifications:
   email: true

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.7
+julia 0.7-alpha
 BinDeps
 ProgressMeter

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.6
+julia 0.7
 BinDeps
 ProgressMeter

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,13 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 
 ## uncomment the following lines to allow failures on nightly julia
 ## (tests will run but not make your overall status red)
-matrix:
-  allow_failures:
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+# matrix:
+#   allow_failures:
+#   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 
 branches:
   only:

--- a/src/TriangleMesh.jl
+++ b/src/TriangleMesh.jl
@@ -5,6 +5,9 @@ Create and refine 2D unstructured triangular meshes. Interfaces
 module TriangleMesh
 
 using ProgressMeter
+using Libdl
+using LinearAlgebra
+using DelimitedFiles
 
 export TriMesh, Polygon_pslg, 
 		create_mesh, refine, refine_rg, 
@@ -32,10 +35,10 @@ export TriMesh, Polygon_pslg,
 # else
 #	push!(Libdl.DL_LOAD_PATH, Pkg.dir() * "/TriangleMesh/deps/usr/lib");
 # end
-if ~isfile(Pkg.dir() * "/TriangleMesh/deps/deps.jl")
+if !isfile(joinpath(@__DIR__, "..", "deps", "deps.jl"))
    error("Triangle library not found. Please run `Pkg.build(\"TriangleMesh\")` first.")
 else
-   push!(Libdl.DL_LOAD_PATH, Pkg.dir() * "/TriangleMesh/deps/usr/lib");
+   push!(Libdl.DL_LOAD_PATH, joinpath(@__DIR__, "..", "deps", "usr", "lib"))
 end
 # ----------------------------------------
 

--- a/src/TriangleMesh_FileIO.jl
+++ b/src/TriangleMesh_FileIO.jl
@@ -44,14 +44,12 @@ function write_mesh_triangle(m :: TriMesh, file_name :: String)
 			thirdline = "# List of nodes, attributes (optional) and markers (optional):\n"
 			write(f, thirdline)
 
-			# zip several arrays of different type
-			cmd = "zip(1:$(m.n_point), $(m.point[1,:]), $(m.point[2,:])"
-			for i in 1:m.n_point_attribute
-       			cmd = cmd * ", $(m.point_attribute)[$(i),:]"
-       		end
-
-			cmd = cmd * ", $(m.point_marker))"
-			data = eval(parse(cmd))
+			data = zip(
+			    1:m.n_point,
+			    m.point[1,:],
+			    m.point[2,:],
+			    [m.point_attribute[i,:] for i in 1:m.n_point_attribute]...,
+			    m.point_marker)
 			writedlm(f, data, " ")
 
 			close(f)
@@ -71,9 +69,7 @@ function write_mesh_triangle(m :: TriMesh, file_name :: String)
 			thirdline = "# List of triangles and attributes (optional):\n"
 			write(f, thirdline)
 
-			# zip several arrays of different type
-			cmd = "zip(1:$(m.n_cell), $(m.cell[1,:]), $(m.cell[2,:]), $(m.cell[3,:]))"
-			data = eval(parse(cmd))
+			data = zip(1:m.n_cell, m.cell[1,:], m.cell[2,:], m.cell[3,:])
 			writedlm(f, data, " ")
 
 			close(f)
@@ -93,9 +89,7 @@ function write_mesh_triangle(m :: TriMesh, file_name :: String)
 			thirdline = "# List of triangle neighbors:\n"
 			write(f, thirdline)
 
-			# zip several arrays of different type
-			cmd = "zip(1:$(m.n_cell), $(m.cell_neighbor[1,:]), $(m.cell_neighbor[2,:]), $(m.cell_neighbor[3,:]))"
-			data = eval(parse(cmd))
+			data = zip(1:m.n_cell, m.cell_neighbor[1,:], m.cell_neighbor[2,:], m.cell_neighbor[3,:])
 			writedlm(f, data, " ")
 
 			close(f)
@@ -115,9 +109,7 @@ function write_mesh_triangle(m :: TriMesh, file_name :: String)
 			thirdline = "# List of edges and boundary markers (optional):\n"
 			write(f, thirdline)
 
-			# zip several arrays of different type
-			cmd = "zip(1:$(m.n_edge), $(m.edge[1,:]), $(m.edge[2,:]), $(m.edge_marker))"
-			data = eval(parse(cmd))
+			data = zip(1:m.n_edge, m.edge[1,:], m.edge[2,:], m.edge_marker)
 			writedlm(f, data, " ")
 
 			close(f)

--- a/src/TriangleMesh_Polygon.jl
+++ b/src/TriangleMesh_Polygon.jl
@@ -36,27 +36,27 @@ function Polygon_pslg(n_point :: Int, n_point_marker :: Int, n_point_attribute :
     
     n_point<1 ? error("Number of polygon points must be positive.") :
     n_point = n_point
-    point = Array{Cdouble,2}(2, n_point)
+    point = Array{Cdouble,2}(undef, 2, n_point)
 
 
-    n_point_marker>1 ? info("Number of point markers > 1. Only 0 or 1 admissible. Set to 1.") :
+    n_point_marker>1 ? @info("Number of point markers > 1. Only 0 or 1 admissible. Set to 1.") :
     n_point_marker = 1
-    point_marker = Array{Cint,2}(n_point_marker, n_point)
+    point_marker = Array{Cint,2}(undef, n_point_marker, n_point)
 
 
     n_point_attribute<0 ? error("Number of point attributes must be positive.") :
     n_point_attribute = n_point_attribute
-    point_attribute = Array{Cdouble,2}(n_point_attribute, n_point)
+    point_attribute = Array{Cdouble,2}(undef, n_point_attribute, n_point)
 
 
     n_segment = n_segment
-    segment = Array{Cint,2}(2,n_segment)
+    segment = Array{Cint,2}(undef, 2,n_segment)
     # Set segment marker to 1 by default.
     segment_marker = ones(Cint,n_segment)
 
     n_hole<0 ? error("Number of point attributes must be a nonnegative integer.") :
     n_hole = n_hole
-    hole = Array{Cdouble,2}(2, n_hole)
+    hole = Array{Cdouble,2}(undef, 2, n_hole)
 
 
     # Call inner constructor
@@ -72,16 +72,16 @@ end
 # -----------------------------------------------------------
 
 """
-    set_polygon_point!(poly :: Polygon_pslg, p :: Array{Float64,2})
+    set_polygon_point!(poly :: Polygon_pslg, p :: AbstractArray{Float64,2})
 
 Set `poly.point` appropriately. Input must have dimensions `n_point`-by-`2`.
 """
-function set_polygon_point!(poly :: Polygon_pslg, p :: Array{Float64,2})
+function set_polygon_point!(poly :: Polygon_pslg, p :: AbstractArray{Float64,2})
 
     if length(p)>0
         size(poly.point)!=size(p') ? error("Polygon constructor: Point size mismatch...") :
 
-        poly.point[:,:] = convert(Array{Cdouble,2}, p)'
+        poly.point[:,:] = convert(Array{Cdouble,2}, p')
     end
 
     return nothing
@@ -93,12 +93,12 @@ end
 
 Set `poly.point_marker` appropriately. Input must have dimensions `n_point`-by-`n_point_marker`. `n_point_marker` can be 1 or 0.
 """
-function set_polygon_point_marker!(poly :: Polygon_pslg, pm :: Array{Int,2})
+function set_polygon_point_marker!(poly :: Polygon_pslg, pm :: AbstractArray{Int,2})
 
     if length(pm)>0
         size(poly.point_marker)!=(size(pm,2), size(pm,1)) ? error("Polygon constructor: Point marker mismatch...") :
 
-        poly.point_marker[:,:] = convert(Array{Cint,2}, pm)'
+        poly.point_marker[:,:] = convert(Array{Cint,2}, pm')
     end
 
     return nothing
@@ -110,12 +110,12 @@ end
 
 Set `poly.point_attribute` appropriately. Input must have dimensions `n_point`-by-`n_point_attribute`.
 """
-function set_polygon_point_attribute!(poly :: Polygon_pslg, pa :: Array{Float64,2})
+function set_polygon_point_attribute!(poly :: Polygon_pslg, pa :: AbstractArray{Float64,2})
 
     if length(pa)>0
         size(poly.point_attribute)!=size(pa') ? error("Polygon constructor: Point attribute mismatch...") :
 
-        poly.point_attribute[:,:] = convert(Array{Cdouble,2}, pa)'
+        poly.point_attribute[:,:] = convert(Array{Cdouble,2}, pa')
     end
 
     return nothing
@@ -127,12 +127,12 @@ end
 
 Set `poly.segment` appropriately. Input must have dimensions `n_segment`-by-`2`.
 """
-function set_polygon_segment!(poly :: Polygon_pslg, s :: Array{Int,2})
+function set_polygon_segment!(poly :: Polygon_pslg, s :: AbstractArray{Int,2})
 
     if length(s)>0
         size(poly.segment)!=size(s') ? error("Polygon constructor: Segment size mismatch...") :
 
-        poly.segment[:,:] = convert(Array{Cint,2}, s)'
+        poly.segment[:,:] = convert(Array{Cint,2}, s')
     end
 
     return nothing
@@ -144,7 +144,7 @@ end
 
 Set `poly.segment_marker` appropriately. Input must have dimensions `n_segment`-by-`1`. If not set every segemnt will have marker equal to 1.
 """
-function set_polygon_segment_marker!(poly :: Polygon_pslg, sm :: Array{Int,1})
+function set_polygon_segment_marker!(poly :: Polygon_pslg, sm :: AbstractArray{Int,1})
 
     if length(sm)>0
         size(poly.segment_marker)!=size(sm) ? error("Polygon constructor: Segment marker mismatch...") :
@@ -164,12 +164,12 @@ Set `poly.hole` appropriately. Input must have dimensions `n_hole`-by-`2`.
 !!!
     Each hole must be enclosed by segments. Do not place holes on segments.
 """
-function set_polygon_hole!(poly :: Polygon_pslg, h :: Array{Float64,2})
+function set_polygon_hole!(poly :: Polygon_pslg, h :: AbstractArray{Float64,2})
 
     if length(h)>0
         size(poly.hole)!=size(h') ? error("Polygon constructor: Hole mismatch...") :
 
-        poly.hole[:,:] = convert(Array{Cdouble,2}, h)'
+        poly.hole[:,:] = convert(Array{Cdouble,2}, h')
     end
 
     return nothing

--- a/src/TriangleMesh_TriMesh.jl
+++ b/src/TriangleMesh_TriMesh.jl
@@ -88,14 +88,14 @@ function TriMesh(mesh :: Mesh_ptr_C, vor :: Mesh_ptr_C, mesh_info :: String)
 
     if mesh.pointlist != C_NULL
         point = convert(Array{Float64,2}, 
-                        unsafe_wrap(Array, mesh.pointlist, (2,n_point), take_ownership))
+                        unsafe_wrap(Array, mesh.pointlist, (2,n_point), own=take_ownership))
     else
         error("Points could not be read from triangulation structure.")
     end
     
     if mesh.pointmarkerlist != C_NULL
         n_point_marker = 1     
-        point_marker = convert(Array{Int,2}, unsafe_wrap(Array, mesh.pointmarkerlist, (1,n_point), take_ownership))
+        point_marker = convert(Array{Int,2}, unsafe_wrap(Array, mesh.pointmarkerlist, (1,n_point), own=take_ownership))
     else
         n_point_marker = 0
         point_marker = Array{Int,2}(0,n_point)
@@ -104,9 +104,9 @@ function TriMesh(mesh :: Mesh_ptr_C, vor :: Mesh_ptr_C, mesh_info :: String)
     n_point_attribute = Int(mesh.numberofpointattributes)
     if n_point_attribute>0
         point_attribute = convert(Array{Float64,2}, 
-                                unsafe_wrap(Array, mesh.pointattributelist, (n_point_attribute, n_point), take_ownership))
+                                unsafe_wrap(Array, mesh.pointattributelist, (n_point_attribute, n_point), own=take_ownership))
     else
-        point_attribute = Array{Float64,2}(0,n_point)
+        point_attribute = Array{Float64,2}(undef,0,n_point)
     end
 
     
@@ -116,7 +116,7 @@ function TriMesh(mesh :: Mesh_ptr_C, vor :: Mesh_ptr_C, mesh_info :: String)
 
     if mesh.trianglelist != C_NULL
         cell = convert(Array{Int,2}, 
-                        unsafe_wrap(Array, mesh.trianglelist, (3, n_cell), take_ownership))
+                        unsafe_wrap(Array, mesh.trianglelist, (3, n_cell), own=take_ownership))
         if minimum(cell)==0
             cell += 1
         end
@@ -126,12 +126,12 @@ function TriMesh(mesh :: Mesh_ptr_C, vor :: Mesh_ptr_C, mesh_info :: String)
 
     if mesh.neighborlist != C_NULL
         cell_neighbor = convert(Array{Int,2},
-                                unsafe_wrap(Array, mesh.neighborlist, (3,n_cell), take_ownership))
+                                unsafe_wrap(Array, mesh.neighborlist, (3,n_cell), own=take_ownership))
         if minimum(cell_neighbor)==-1
-            cell_neighbor += 1
+            cell_neighbor .+= 1
         end
     else
-        cell_neighbor = Array{Int,2}(0,n_cell)
+        cell_neighbor = Array{Int,2}(undef,0,n_cell)
     end
 
 
@@ -139,23 +139,23 @@ function TriMesh(mesh :: Mesh_ptr_C, vor :: Mesh_ptr_C, mesh_info :: String)
     if mesh.edgelist != C_NULL
         n_edge = Int(mesh.numberofedges)
         edge = convert(Array{Int,2},
-                        unsafe_wrap(Array, mesh.edgelist, (2, n_edge), take_ownership))
+                        unsafe_wrap(Array, mesh.edgelist, (2, n_edge), own=take_ownership))
         if minimum(edge)==0
             edge += 1
         end
     else
         n_edge = 0
-        edge = Array{Int,2}(2,0)
+        edge = Array{Int,2}(undef,2,0)
    
     end
 
     if mesh.edgemarkerlist != C_NULL
         n_edge_marker = 1
         edge_marker = convert(Array{Int,1},
-                                unsafe_wrap(Array, mesh.edgemarkerlist, n_edge, take_ownership))
+                                unsafe_wrap(Array, mesh.edgemarkerlist, n_edge, own=take_ownership))
     else
         n_edge_marker = 0
-        edge_marker = Array{Int,1}(0)
+        edge_marker = Array{Int,1}(undef,0)
     end
 
 
@@ -163,22 +163,22 @@ function TriMesh(mesh :: Mesh_ptr_C, vor :: Mesh_ptr_C, mesh_info :: String)
     if mesh.segmentlist != C_NULL
         n_segment = Int(mesh.numberofsegments)
         segment = convert(Array{Int,2}, 
-                            unsafe_wrap(Array, mesh.segmentlist, (2,n_segment), take_ownership))
+                            unsafe_wrap(Array, mesh.segmentlist, (2,n_segment), own=take_ownership))
         if minimum(segment)==0
             segment += 1
         end
     else
         n_segment = 0
-        segment = Array{Int,2}(2,0)
+        segment = Array{Int,2}(undef,2,0)
     end
 
     if mesh.segmentmarkerlist != C_NULL
         n_segment_marker = 1
         segment_marker = convert(Array{Int,1},
-                                unsafe_wrap(Array, mesh.segmentmarkerlist, n_segment, take_ownership))
+                                unsafe_wrap(Array, mesh.segmentmarkerlist, n_segment, own=take_ownership))
     else
         n_segment_marker = 0
-        segment_marker = Array{Int,1}(0)
+        segment_marker = Array{Int,1}(undef,0)
     end
 
 
@@ -186,10 +186,10 @@ function TriMesh(mesh :: Mesh_ptr_C, vor :: Mesh_ptr_C, mesh_info :: String)
     if mesh.holelist != C_NULL
         n_hole = Int(mesh.numberofholes)
         hole = convert(Array{Float64,2},
-                        unsafe_wrap(Array, mesh.holelist, (2, n_hole), take_ownership))
+                        unsafe_wrap(Array, mesh.holelist, (2, n_hole), own=take_ownership))
     else
         n_hole = 0
-        hole = Array{Float64,2}(2, 0)
+        hole = Array{Float64,2}(undef,2, 0)
     end
     
     # ----------------------------------------
@@ -201,14 +201,14 @@ function TriMesh(mesh :: Mesh_ptr_C, vor :: Mesh_ptr_C, mesh_info :: String)
         # Points
         n_point_v = Int(vor.numberofpoints)
         point_v = convert(Array{Float64,2},
-                                unsafe_wrap(Array, vor.pointlist, (2,n_point), take_ownership))
+                                unsafe_wrap(Array, vor.pointlist, (2,n_point), own=take_ownership))
 
         n_point_attribute_v = Int(vor.numberofpointattributes)
         if n_point_attribute_v>0
             point_attribute_v = convert(Array{Float64,2}, 
-                                    unsafe_wrap(Array, vor.pointattributelist, (n_point_attribute_v, n_point_v), take_ownership))
+                                    unsafe_wrap(Array, vor.pointattributelist, (n_point_attribute_v, n_point_v), own=take_ownership))
         else
-            point_attribute_v = Array{Float64,2}(0,n_point_v)
+            point_attribute_v = Array{Float64,2}(undef,0,n_point_v)
         end
 
         
@@ -216,31 +216,31 @@ function TriMesh(mesh :: Mesh_ptr_C, vor :: Mesh_ptr_C, mesh_info :: String)
         n_edge_v = Int(vor.numberofedges)
         if n_edge_v>0
             edge_v = convert(Array{Int,2}, 
-                            unsafe_wrap(Array, vor.edgelist, (2, n_edge_v), take_ownership))
+                            unsafe_wrap(Array, vor.edgelist, (2, n_edge_v), own=take_ownership))
             if minimum(edge_v)==0
                 edge_v += 1
             end
             
             if vor.normlist != C_NULL
             normal_v = convert(Array{Float64,2}, 
-                            unsafe_wrap(Array, vor.edgelist, (2, n_edge_v), take_ownership))
+                            unsafe_wrap(Array, vor.edgelist, (2, n_edge_v), own=take_ownership))
             else
-                normal_v = Array{Float64,2}(2, 0)
+                normal_v = Array{Float64,2}(undef,2, 0)
             end
         else
-            edge_v = Array{Int,2}(0,2)
-            normal_v = Array{Float64,2}(2, 0)
+            edge_v = Array{Int,2}(undef,0,2)
+            normal_v = Array{Float64,2}(undef,2, 0)
         end
     else
         n_point_v = 0
-        point_v = Array{Float64,2}(2,0)
+        point_v = Array{Float64,2}(undef,2,0)
 
         n_point_attribute_v = 0
-        point_attribute_v = Array{Float64,2}(1,0)
+        point_attribute_v = Array{Float64,2}(undef,1,0)
 
         n_edge_v = 0
-        edge_v = Array{Int,2}(2, 0)
-        normal_v = Array{Float64,2}(2, 0)
+        edge_v = Array{Int,2}(undef,2, 0)
+        normal_v = Array{Float64,2}(undef,2, 0)
     end
 
     voronoi = VoronoiDiagram(vor_info, 

--- a/src/TriangleMesh_create_mesh.jl
+++ b/src/TriangleMesh_create_mesh.jl
@@ -156,7 +156,7 @@ function create_mesh(poly :: Polygon_pslg;
     # This enables to use aditional switches and should be used with care
     switches = switches * add_switches
 
-    contains(switches, "z") ? error("Triangle switches must not contain `z`. Zero based indexing is not allowed.") :
+    occursin("z", switches) ? error("Triangle switches must not contain `z`. Zero based indexing is not allowed.") :
 
     mesh_in = Mesh_ptr_C(poly)
 
@@ -164,7 +164,7 @@ function create_mesh(poly :: Polygon_pslg;
     vor_buffer = Mesh_ptr_C()
 
     ccall((:tesselate_pslg, "libtesselate"), 
-                        Void,
+                        Nothing,
                         (Ref{Mesh_ptr_C}, 
                             Ref{Mesh_ptr_C},
                             Ref{Mesh_ptr_C},
@@ -189,7 +189,7 @@ for Triangle. Use only if you know what you are doing.
 function create_mesh(poly :: Polygon_pslg, switches :: String;
                                 info_str :: String = "Triangular mesh of polygon (PSLG)")
     
-    contains(switches, "z") ? error("Triangle switches must not contain `z`. Zero based indexing is not allowed.") :
+    occursin("z", switches) ? error("Triangle switches must not contain `z`. Zero based indexing is not allowed.") :
 
     mesh_in = Mesh_ptr_C(poly)
 
@@ -197,7 +197,7 @@ function create_mesh(poly :: Polygon_pslg, switches :: String;
     vor_buffer = Mesh_ptr_C()
 
     ccall((:tesselate_pslg, "libtesselate"), 
-                        Void,
+                        Nothing,
                         (Ref{Mesh_ptr_C}, 
                             Ref{Mesh_ptr_C},
                             Ref{Mesh_ptr_C},
@@ -224,8 +224,8 @@ end
 Creates a triangulation of the convex hull of a point cloud.
 
 # Keyword arguments
-- `point_marker :: Array{Int,2} = Array{Int,2}(0,size(point,1))`: Points can have a marker.
-- `point_attribute :: Array{Float64,2} = Array{Float64,2}(0,size(point,1))`: Points can be 
+- `point_marker :: Array{Int,2} = Array{Int,2}(undef,0,size(point,1))`: Points can have a marker.
+- `point_attribute :: Array{Float64,2} = Array{Float64,2}(undef,0,size(point,1))`: Points can be 
                                                                             given a number
                                                                             of attributes.
 - `info_str :: String = "Triangular mesh of convex hull of point cloud."`: Some mesh info on the mesh
@@ -256,8 +256,8 @@ Creates a triangulation of the convex hull of a point cloud.
 
 """
 function create_mesh(point :: Array{Float64,2}; 
-                            point_marker :: Array{Int,2} = Array{Int,2}(0,size(point,1)),
-                            point_attribute :: Array{Float64,2} = Array{Float64,2}(0,size(point,1)),
+                            point_marker :: Array{Int,2} = Array{Int,2}(undef,0,size(point,1)),
+                            point_attribute :: Array{Float64,2} = Array{Float64,2}(undef,0,size(point,1)),
                             info_str :: String = "Triangular mesh of convex hull of point cloud.",
                             verbose :: Bool = false,
                             check_triangulation :: Bool = false,
@@ -373,7 +373,7 @@ function create_mesh(point :: Array{Float64,2};
     # This enables to use aditional switches and should be used with care
     switches = switches * add_switches
   
-    contains(switches, "z") ? error("Triangle switches must not contain `z`. Zero based indexing is not allowed.") :
+    occursin("z", switches) ? error("Triangle switches must not contain `z`. Zero based indexing is not allowed.") :
 
 
     poly = polygon_struct_from_points(point, point_marker, point_attribute)
@@ -394,20 +394,20 @@ Options for the meshing algorithm are passed directly by command line switches
 for Triangle. Use only if you know what you are doing.
 
 # Keyword arguments
-- `point_marker :: Array{Int,2} = Array{Int,2}(0,size(point,1))`: Points can have a marker.
-- `point_attribute :: Array{Float64,2} = Array{Float64,2}(0,size(point,1))`: Points can be 
+- `point_marker :: Array{Int,2} = Array{Int,2}(undef,0,size(point,1))`: Points can have a marker.
+- `point_attribute :: Array{Float64,2} = Array{Float64,2}(undef,0,size(point,1))`: Points can be 
                                                                             given a number
                                                                             of attributes.
 - `info_str :: String = "Triangular mesh of convex hull of point cloud."`: Some mesh info on the mesh
 """
 function create_mesh(point :: Array{Float64,2}, switches :: String;
-                                    point_marker :: Array{Int,2} = Array{Int,2}(0,size(point,1)),
-                                    point_attribute :: Array{Float64,2} = Array{Float64,2}(0,size(point,1)),
+                                    point_marker :: Array{Int,2} = Array{Int,2}(undef,0,size(point,1)),
+                                    point_attribute :: Array{Float64,2} = Array{Float64,2}(undef,0,size(point,1)),
                                     info_str :: String = "Triangular mesh of convex hull of point cloud.")
   
-    contains(switches, "z") ? error("Triangle switches must not contain `z`. Zero based indexing is not allowed.") :
+    occursin("z", switches) ? error("Triangle switches must not contain `z`. Zero based indexing is not allowed.") :
 
-    if ~contains(switches, "c") 
+    if ~occursin("c", switches) 
         info("Option `-c` added. Triangle switches must contain the -c option for point clouds.")
         switches = switches * "c"
     end

--- a/src/TriangleMesh_polygon_constructors.jl
+++ b/src/TriangleMesh_polygon_constructors.jl
@@ -97,7 +97,7 @@ function polygon_regular(n_corner :: Int)
 
     # 4 points
     point = zeros(n_point,2)
-    phi = linspace(0, 2*pi, n_point+1)[1:end-1]
+    phi = range(0, stop=2*pi, length=n_point+1)[1:end-1]
     point = [cos.(phi) sin.(phi)]
     set_polygon_point!(poly, point)
 
@@ -216,7 +216,7 @@ Create a polygon from a set of points (example code). No segments or holes are s
 # Arguments
 - `point :: Array{Float64,2}`: point set (dimension n-by-2)
 - `pm :: Array{Int,2}`: each point can have a marker (dimension either n-by-0 or n-by-1)
-- `pa :: Array{Float64,2}`: each point can have a number of ``k\>=0``real attributes (dimension n-by-k)
+- `pa :: Array{Float64,2}`: each point can have a number of ``k \\geq 0``real attributes (dimension n-by-k)
 """
 function polygon_struct_from_points(point :: Array{Float64,2},
                                     pm :: Array{Int,2},

--- a/src/TriangleMesh_refine.jl
+++ b/src/TriangleMesh_refine.jl
@@ -116,8 +116,8 @@ function refine(m :: TriMesh ; divide_cell_into :: Int = 4,
             segment_marker = convert(Array{Cint,1}, m.segment_marker)
             switches = switches * "p"
         else
-            segment = Array{Cint,2}(2,0)
-            segment_marker = Array{Cint,1}(0)
+            segment = Array{Cint,2}(undef,2,0)
+            segment_marker = Array{Cint,1}(undef,0)
         end
     elseif keep_edges
         # If there are edges use them
@@ -132,14 +132,14 @@ function refine(m :: TriMesh ; divide_cell_into :: Int = 4,
             segment_marker = convert(Array{Cint,1}, m.edge_marker)
             switches = switches * "p"
         else
-            segment = Array{Cint,2}(2,0)
-            segment_marker = Array{Cint,1}(0)
+            segment = Array{Cint,2}(undef,2,0)
+            segment_marker = Array{Cint,1}(undef,0)
         end
     else
         n_segment = Cint(0)
-        segment = Array{Cint,2}(2,0)
-        segment_marker = Array{Cint,1}(0)
-        info("Neither segments nor edges will be kept during the refinedment.")
+        segment = Array{Cint,2}(undef,2,0)
+        segment_marker = Array{Cint,1}(undef,0)
+        @info("Neither segments nor edges will be kept during the refinedment.")
     end
 
 
@@ -154,8 +154,8 @@ function refine(m :: TriMesh ; divide_cell_into :: Int = 4,
         edge = convert(Array{Cint,2}, m.edge)
         edge_marker = convert(Array{Cint,1}, m.edge_marker)
     else
-        edges = Array{Cint,2}(2,0)
-        edge_marker = Array{Cint,1}(0)
+        edges = Array{Cint,2}(undef,2,0)
+        edge_marker = Array{Cint,1}(undef,0)
     end
 
     # If there are point marker then use them
@@ -163,7 +163,7 @@ function refine(m :: TriMesh ; divide_cell_into :: Int = 4,
     if n_point_marker==1
         point_marker = convert(Array{Cint,2}, m.point_marker)
     elseif n_point_marker==0
-        point_marker = Array{Cint,2}(0,n_point)
+        point_marker = Array{Cint,2}(undef,0,n_point)
     else
         error("Number of n_point_marker must either be 0 or 1.")
     end
@@ -174,7 +174,7 @@ function refine(m :: TriMesh ; divide_cell_into :: Int = 4,
     if n_point_attribute>0
         point_attribute = convert(Array{Cdouble,2}, m.point_attribute)
     else
-        point_attribute = Array{Cdouble,2}(0,n_point)
+        point_attribute = Array{Cdouble,2}(undef,0,n_point)
     end
 
 
@@ -182,7 +182,7 @@ function refine(m :: TriMesh ; divide_cell_into :: Int = 4,
     if n_hole>0
         hole = convert(Array{Cdouble,2}, m.hole)
     else
-        hole = Array{Cdouble,2}(2,n_hole)
+        hole = Array{Cdouble,2}(undef,2,n_hole)
     end
 
     mesh_in = Mesh_ptr_C(n_point, point,
@@ -197,7 +197,7 @@ function refine(m :: TriMesh ; divide_cell_into :: Int = 4,
     vor_buffer = Mesh_ptr_C()
 
     ccall((:refine_trimesh, "libtesselate"), 
-                            Void,
+                            Nothing,
                             (Ref{Mesh_ptr_C}, 
                                 Ref{Mesh_ptr_C},
                                 Ref{Mesh_ptr_C},
@@ -261,8 +261,8 @@ function refine(m :: TriMesh, switches :: String;
         segment = convert(Array{Cint,2}, m.segment)
         segment_marker = convert(Array{Cint,1}, m.segment_marker)
     else
-        segment = Array{Cint,2}(2,0)
-        segment_marker = Array{Cint,1}(0)
+        segment = Array{Cint,2}(undef,2,0)
+        segment_marker = Array{Cint,1}(undef,0)
     end
 
 
@@ -272,8 +272,8 @@ function refine(m :: TriMesh, switches :: String;
         edge = convert(Array{Cint,2}, m.edge)
         edge_marker = convert(Array{Cint,1}, m.edge_marker)
     else
-        edge = Array{Cint,2}(2,0)
-        edge_marker = Array{Cint,1}(0)
+        edge = Array{Cint,2}(undef,2,0)
+        edge_marker = Array{Cint,1}(undef,0)
     end
 
     # If there are point marker then use them
@@ -300,7 +300,7 @@ function refine(m :: TriMesh, switches :: String;
     if n_hole>0
         hole = convert(Array{Cdouble,2}, m.hole)
     else
-        hole = Array{Cdouble,2}(2,n_hole)
+        hole = Array{Cdouble,2}(undef,2,n_hole)
     end
 
     mesh_in = Mesh_ptr_C(n_point, point,
@@ -315,7 +315,7 @@ function refine(m :: TriMesh, switches :: String;
     vor_buffer = Mesh_ptr_C()
 
     ccall((:refine_trimesh, "libtesselate"), 
-                            Void,
+                            Nothing,
                             (Ref{Mesh_ptr_C}, 
                                 Ref{Mesh_ptr_C},
                                 Ref{Mesh_ptr_C},

--- a/src/TriangleMesh_refine_rg.jl
+++ b/src/TriangleMesh_refine_rg.jl
@@ -85,15 +85,15 @@ function refine_rg(m :: TriMesh, ind_red :: Array{Int,1})
             m.cell[2,i] m.cell[3,i] ; 
             m.cell[3,i] m.cell[1,i]]
         for j in 1:3
-            ind_found = find(all(m.edge.==[e[j,1] ; e[j,2]],1))
+            ind_found = findall(all(m.edge.==[e[j,1] ; e[j,2]],dims=1))
             if isempty(ind_found)
-                ind_found = find(all(m.edge.==[e[j,2] ; e[j,1]],1))
+                ind_found = findall(all(m.edge.==[e[j,2] ; e[j,1]],dims=1))
             end
-            refinement_marker[ind_found] = true
+            refinement_marker[LinearIndices(ind_found)] .= true
         end
         next!(progress)
     end
-    ind_refine_edge = find(refinement_marker)
+    ind_refine_edge = findall(refinement_marker)
 
 
     # Step 2: Set up a new poly structure with points and segements. Ignore

--- a/test/Test_Polygon.jl
+++ b/test/Test_Polygon.jl
@@ -39,7 +39,7 @@
 			N = rand(5:10, 5)
 			for i in N
 				p = polygon_regular(i)
-				norm_points = sum(p.point.^2,1)[:]
+				norm_points = sum(p.point.^2, dims=1)[:]
 				@test isapprox(norm_points, ones(i))
 				@test size(p.segment) == (2,i)
 				@test p.n_hole == 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using TriangleMesh
-using Base.Test
+using Compat.Test
 
 include("Test_Polygon.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using TriangleMesh
-using Compat.Test
+using Test
 
 include("Test_Polygon.jl")
 


### PR DESCRIPTION
Happy [Upgradathon Friday](https://discourse.julialang.org/t/ann-introducing-upgradathon-fridays/12047)!

This PR fixes all the tests and all deprecation warnings on the latest Julia v0.7 nightly. It also bumps the minimum Julia version to v0.7. 

There are only a few nontrivial changes:
* Use relative paths instead of Pkg.dir(). This is actually better on v0.6 as well, since there's no guarantee that packages are installed in Pkg.dir()
* Allow `AbstractArray` inputs in a few places. This is because the `'` operator is now lazy, so `A'` produces a lazy `Adjoint` wrapper instead of a new plain `Array`. I also changed `convert(Array{...}, p)'` to `convert(Array{...}, p')` which will be more efficient when `p` is already transposed (since the `'` just un-does the lazy transpose and doesn't have to copy the data). 
* Remove all of the `eval(parse())` calls